### PR TITLE
ツイートのvalidate実装

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,2 +1,3 @@
 class Post < ApplicationRecord
+    validates :content, {presence: true, length:{maximum: 140}}
 end


### PR DESCRIPTION
変更の概要
新規投稿の空データと140字以上の文章は投稿できないようにvalidateをかけた。

やったこと
post.rbにpresence:trueとlength:{maximum: 140}の追記